### PR TITLE
Implement scroll-triggered fade for skills

### DIFF
--- a/src/components/SkillItem.vue
+++ b/src/components/SkillItem.vue
@@ -17,6 +17,7 @@ defineProps<{
   display: flex;
   flex-direction: column;
   align-items: center;
+  opacity: 0;
 }
 
 .skill-icon {

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -7,13 +7,19 @@
         with modern technologies to build fast and accessible applications.
       </p>
     </div>
-    <div class="skills grid">
-      <SkillItem v-for="skill in skills" :key="skill.name" :icon="skill.icon" :name="skill.name" />
+    <div class="skills grid" ref="skillsContainer">
+      <SkillItem
+        v-for="skill in skills"
+        :key="skill.name"
+        :icon="skill.icon"
+        :name="skill.name"
+      />
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
+import { onMounted, getCurrentInstance, ref } from 'vue'
 import SkillItem from '@/components/SkillItem.vue'
 
 interface Skill {
@@ -27,6 +33,36 @@ const skills: Skill[] = [
   { icon: new URL('../assets/logo.svg', import.meta.url).href, name: 'HTML' },
   { icon: new URL('../assets/logo.svg', import.meta.url).href, name: 'CSS' },
 ]
+
+const skillsContainer = ref<HTMLElement | null>(null)
+
+onMounted(() => {
+  const { $gsap } = getCurrentInstance()!.appContext.config.globalProperties
+  const items = skillsContainer.value
+    ? Array.from(skillsContainer.value.querySelectorAll<HTMLElement>('.skill-item'))
+    : []
+  items.forEach((el) => $gsap.set(el, { opacity: 0, y: 20 }))
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const index = items.indexOf(entry.target as HTMLElement)
+          $gsap.to(entry.target, {
+            opacity: 1,
+            y: 0,
+            duration: 0.6,
+            delay: index * 0.2,
+          })
+          observer.unobserve(entry.target)
+        }
+      })
+    },
+    { threshold: 0.1 }
+  )
+
+  items.forEach((el) => observer.observe(el))
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- fade SkillItem elements as they enter the viewport
- keep SkillItem hidden by default

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6840918dadf8832bbfe1e9e2336e6fc9