### PR TITLE
Add ProjectCard component

### DIFF
--- a/src/components/ProjectCard.vue
+++ b/src/components/ProjectCard.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+defineProps<{
+  title: string
+  image: string
+  description: string
+  link: string
+}>()
+</script>
+
+<template>
+  <div class="project-card">
+    <img :src="image" :alt="title" class="project-image" />
+    <h3 class="project-title">{{ title }}</h3>
+    <p class="project-description">{{ description }}</p>
+    <a :href="link" target="_blank" rel="noopener" class="project-link">
+      View Project
+    </a>
+  </div>
+</template>
+
+<style scoped>
+.project-card {
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.project-image {
+  width: 100%;
+  height: auto;
+  border-radius: 4px;
+}
+
+.project-title {
+  margin-top: 0.5rem;
+  font-size: 1.25rem;
+}
+
+.project-description {
+  margin: 0.5rem 0 1rem;
+}
+
+.project-link {
+  color: #42b983;
+  text-decoration: none;
+  font-weight: bold;
+}
+</style>

--- a/tests/ProjectCard.spec.ts
+++ b/tests/ProjectCard.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ProjectCard from '@/components/ProjectCard.vue'
+
+describe('ProjectCard', () => {
+  it('renders props correctly', () => {
+    const wrapper = mount(ProjectCard, {
+      props: {
+        title: 'Test Project',
+        image: '/img.png',
+        description: 'A cool project',
+        link: 'https://example.com'
+      }
+    })
+
+    expect(wrapper.text()).toContain('Test Project')
+    expect(wrapper.text()).toContain('A cool project')
+
+    const img = wrapper.get('img')
+    expect(img.attributes('src')).toBe('/img.png')
+    expect(img.attributes('alt')).toBe('Test Project')
+
+    const anchor = wrapper.get('a')
+    expect(anchor.attributes('href')).toBe('https://example.com')
+  })
+})


### PR DESCRIPTION
## Summary
- build simple `<ProjectCard>` component
- test project card rendering

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68409468d640832ba09eeea02ed24e1e